### PR TITLE
"Fixes and changes"

### DIFF
--- a/scripts/dmodels_loader.dsc
+++ b/scripts/dmodels_loader.dsc
@@ -40,9 +40,10 @@ dmodels_load_bbmodel:
     script:
     - debug log "[DModels] loading <[model_name].custom_color[emphasis]>"
     # =============== Prep ===============
+    - define model_name_lowercased <[model_name].to_lowercase>
     - define pack_root <script[dmodels_config].parsed_key[resource_pack_path]>
-    - define models_root <[pack_root]>/assets/minecraft/models/item/dmodels/<[model_name]>
-    - define textures_root <[pack_root]>/assets/minecraft/textures/dmodels/<[model_name]>
+    - define models_root <[pack_root]>/assets/minecraft/models/item/dmodels/<[model_name_lowercased]>
+    - define textures_root <[pack_root]>/assets/minecraft/textures/dmodels/<[model_name_lowercased]>
     - define item_validate <item[<script[dmodels_config].parsed_key[item]>]||null>
     - if <[item_validate]> == null:
       - debug error "[DModels] Item must be valid Example: potion"
@@ -51,6 +52,7 @@ dmodels_load_bbmodel:
     - define file data/dmodels/<[model_name]>.bbmodel
     - define scale_factor <element[0.25].div[4.0]>
     - define mc_texture_data <map>
+    - define pack_indent <script[dmodels_config].parsed_key[resource_pack_indent]>
     - flag server dmodels_data.temp_<[model_name]>:!
     # =============== BBModel loading and validation ===============
     - if !<util.has_file[<[file]>]>:
@@ -70,16 +72,17 @@ dmodels_load_bbmodel:
         - debug error "[DModels] Can't load bbmodel for '<[model_name]>' - file has no elements?"
         - stop
     # =============== Pack validation ===============
-    - define packversion 13
+    - define packversion <script[dmodels_config].data_key[resource_pack_version]>
     - if !<util.has_file[<[pack_root]>/pack.mcmeta]>:
-        - run dmodels_multiwaitable_filewrite def.key:core def.path:<[pack_root]>/pack.mcmeta def.data:<map.with[pack].as[<map[pack_format=<[packversion]>;description=dModels_AutoPack_Default]>].to_json[native_types=true;indent=4].utf8_encode>
+        - run dmodels_multiwaitable_filewrite def.key:core def.path:<[pack_root]>/pack.mcmeta def.data:<map.with[pack].as[<map[pack_format=<[packversion]>;description=dModels_AutoPack_Default]>].to_json[native_types=true;indent=<[pack_indent]>].utf8_encode>
     - else if <server.flag[dmodels_last_pack_version]||0> != <[packversion]>:
         - ~fileread path:<[pack_root]>/pack.mcmeta save:mcmeta
         - define mcmeta_data <util.parse_yaml[<entry[mcmeta].data.utf8_decode>]>
         - define mcmeta_data.pack.pack_format <[packversion]>
-        - run dmodels_multiwaitable_filewrite def.key:core def.path:<[pack_root]>/pack.mcmeta def.data:<[mcmeta_data].to_json[native_types=true;indent=4].utf8_encode>
+        - run dmodels_multiwaitable_filewrite def.key:core def.path:<[pack_root]>/pack.mcmeta def.data:<[mcmeta_data].to_json[native_types=true;indent=<[pack_indent]>].utf8_encode>
     - flag server dmodels_last_pack_version:<[packversion]>
     # =============== Textures loading ===============
+    - define mcmetas <[data.mcmetas]||<map>>
     - define tex_id 0
     - define texture_paths <list>
     - foreach <[data.textures]||<list>> as:texture:
@@ -90,9 +93,14 @@ dmodels_load_bbmodel:
         - if !<[raw_source].starts_with[data:image/png;base64,]>:
             - debug error "[DModels] Can't load bbmodel for '<[model_name]>': invalid texture source data."
             - stop
+        - define tex_uuid <[texture.uuid]>
+        - foreach <[mcmetas]> key:meta_uuid as:meta_data:
+            - if <[tex_uuid]> == <[meta_uuid]>:
+                - define texture_meta_path <[textures_root]>/<[texname]>.png.mcmeta
+                - run dmodels_multiwaitable_filewrite def.key:<[model_name]> def.path:<[texture_meta_path]> def.data:<[meta_data].to_json[native_types=true;indent=<[pack_indent]>].utf8_encode>
         - define texture_output_path <[textures_root]>/<[texname]>.png
         - run dmodels_multiwaitable_filewrite def.key:<[model_name]> def.path:<[texture_output_path]> def.data:<[raw_source].after[,].base64_to_binary>
-        - define proper_path dmodels/<[model_name]>/<[texname]>
+        - define proper_path dmodels/<[model_name_lowercased]>/<[texname]>
         - define mc_texture_data.<[tex_id]> <[proper_path]>
         - define texture_paths:->:<[proper_path]>
         - if <[texture.particle]||false>:
@@ -177,7 +185,7 @@ dmodels_load_bbmodel:
                 source: <[new_dir]>
                 prefix: <[new_dir]>/
             - define atlas_data.sources:->:<[src]>
-        - define new_atlas_json <[atlas_data].to_json[indent=4].utf8_encode>
+        - define new_atlas_json <[atlas_data].to_json[indent=<[pack_indent]>].utf8_encode>
         - flag server dmodels_temp_atlas_file:<[new_atlas_json]> expire:1h
         - waituntil rate:1t max:15s !<server.has_flag[dmodels_data.temp_core.filewrites.<[atlas_file].escaped>]>
         - run dmodels_multiwaitable_filewrite def.key:core def.path:<[atlas_file]> def.data:<[new_atlas_json]>
@@ -227,8 +235,8 @@ dmodels_load_bbmodel:
             - define model_json.groups <list[<[json_group]>]>
             - define model_json.display.head.translation <list[32|32|32]>
             - define model_json.display.head.scale <list[4|4|4]>
-            - define modelpath item/dmodels/<[model_name]>/<[outline.name].to_lowercase>
-            - run dmodels_multiwaitable_filewrite def.key:<[model_name]> def.path:<[models_root]>/<[outline.name].to_lowercase>.json def.data:<[model_json].to_json[native_types=true;indent=4].utf8_encode>
+            - define modelpath item/dmodels/<[model_name_lowercased]>/<[outline.name].to_lowercase>
+            - run dmodels_multiwaitable_filewrite def.key:<[model_name]> def.path:<[models_root]>/<[outline.name].to_lowercase>.json def.data:<[model_json].to_json[native_types=true;indent=<[pack_indent]>].utf8_encode>
             - define cmd 0
             - define min_cmd 1000
             - foreach <[override_item_data.overrides]||<list>> as:override:
@@ -245,7 +253,7 @@ dmodels_load_bbmodel:
         - define outline.rotation <proc[dmodels_quaternion_from_euler].context[<[rotation].parse[to_radians]>]>
         - flag server dmodels_data.model_<[model_name]>.<[outline.uuid]>:<[outline]>
     - if <[overrides_changed]>:
-        - define override_file_json <[override_item_data].to_json[native_types=true;indent=4].utf8_encode>
+        - define override_file_json <[override_item_data].to_json[native_types=true;indent=<[pack_indent]>].utf8_encode>
         - flag server dmodels_temp_item_file:<[override_file_json]> expire:1h
         - waituntil rate:1t max:15s !<server.has_flag[dmodels_data.temp_core.filewrites.<[override_item_filepath].escaped>]>
         - run dmodels_multiwaitable_filewrite def.key:<[model_name]> def.path:<[override_item_filepath]> def.data:<[override_file_json]>

--- a/scripts/dmodels_main.dsc
+++ b/scripts/dmodels_main.dsc
@@ -9,9 +9,9 @@
 # @contributors Max^
 # @thanks Darwin, Max^, kalebbroo, sharklaserss - for helping with reference models, testing, ideas, etc
 # @date 2022/06/01
-# @updated 2023/05/12
+# @updated 2023/09/08
 # @denizen-build REL-1793
-# @script-version 2.0
+# @script-version 2.1
 #
 # This takes BlockBench "BBModel" files, converts them to a client-ready resource pack and Denizen internal data,
 # then is able to display them in minecraft and even animate them, by spawning and moving item display entities with resource pack items.
@@ -77,7 +77,7 @@
 # # To rotate a model
 # - run dmodels_set_rotation def.root_entity:<[root]> def.quaternion:identity
 # # To scale a model
-# - run dmodels_scale_model def.root_entity:<[root]> def.scale:1,1,1
+# - run dmodels_set_scale def.root_entity:<[root]> def.scale:1,1,1
 # # To set the color of a model
 # - run dmodels_set_color def.root_entity:<[root]> def.color:red
 #
@@ -136,3 +136,7 @@ dmodels_config:
     resource_pack_path: data/dmodels/res_pack
     # During the loading process the scale is shrunken down exactly 2.2 for items to allow bigger models in block bench so this brings it back up to default scale in-game (this is an estimate)
     default_scale: 2.2
+    # You can optionally set the json indent for the resource pack to save space (0 for example).
+    resource_pack_indent: 4
+    # Set the resource pack version https://minecraft.fandom.com/wiki/Pack_format
+    resource_pack_version: 13

--- a/scripts/dmodels_spawning.dsc
+++ b/scripts/dmodels_spawning.dsc
@@ -19,7 +19,7 @@ dmodels_spawn_model:
     - if !<server.has_flag[dmodels_data.model_<[model_name]>]>:
         - debug error "[DModels] cannot spawn model <[model_name]>, model not loaded"
         - stop
-    - define center <[location].with_pitch[0].below[1]>
+    - define center <[location].with_pose[0,0].below[1]>
     - define scale <[scale].if_null[<location[1,1,1]>].mul[<script[dmodels_config].parsed_key[default_scale]>]>
     - define rotation <[rotation].if_null[<quaternion[identity]>]>
     - define yaw_quaternion <location[0,1,0].to_axis_angle_quaternion[<[location].yaw.add[180].to_radians.mul[-1]>]>


### PR DESCRIPTION
- Added support for animated mcmeta images
- Center location when spawning now uses .with_pose[0,0]
- Added 2 additional config options for the loading process the first one allows you to set the json indent and the second you can set the resource pack version
- I encountered an invalid path issue when loading a model with an uppercase name for the file paths so I added model_name_lowercased to prevent that
- Fixed API detail on set scale in main