### PR TITLE
Update to 1.20.1

### DIFF
--- a/scripts/dmodels_animating.dsc
+++ b/scripts/dmodels_animating.dsc
@@ -58,11 +58,9 @@ dmodels_move_to_frame:
             - case hold:
                 - define timespot <[animation_data.length]>
                 - flag server dmodels_anim_active.<[root_entity].uuid>:!
-    - define global_rotation <[root_entity].flag[dmodel_global_rotation]>
     - define global_scale <[root_entity].flag[dmodel_global_scale].mul[<script[dmodels_config].parsed_key[default_scale]>]>
-    - define center <[root_entity].location.with_pitch[0].below[1]>
-    - define yaw_quaternion <location[0,1,0].to_axis_angle_quaternion[<[root_entity].flag[dmodel_yaw].add[180].to_radians.mul[-1]>]>
-    - define orientation <[yaw_quaternion].mul[<[global_rotation]>]>
+    - define center <[root_entity].location.with_yaw[<[root_entity].location.yaw.add[180]>].with_pitch[0].below[1]>
+    - define orientation <[root_entity].flag[dmodel_global_rotation]>
     - define parentage <map>
     - foreach <[animation_data.animators]> key:part_id as:animator:
         - define framedata.position <location[0,0,0]>

--- a/scripts/dmodels_loader.dsc
+++ b/scripts/dmodels_loader.dsc
@@ -244,8 +244,9 @@ dmodels_load_bbmodel:
             #### Item override building
             - definemap json_group name:<[outline.name].to_lowercase> color:0 children:<util.list_numbers[from=0;to=<[child_count]>]> origin:<[outline_origin].mul[<[scale_factor]>].xyz.split[,]>
             - define model_json.groups <list[<[json_group]>]>
-            - define model_json.display.head.translation <list[32|32|32]>
+            - define model_json.display.head.translation <list[-32|32|-32]>
             - define model_json.display.head.scale <list[4|4|4]>
+            - define model_json.display.head.rotation <list[0|180|0]>
             - define modelpath item/dmodels/<[model_name_lowercased]>/<[outline.name].to_lowercase>
             - run dmodels_multiwaitable_filewrite def.key:<[model_name]> def.path:<[models_root]>/<[outline.name].to_lowercase>.json def.data:<[model_json].to_json[native_types=true;indent=<[pack_indent]>].utf8_encode>
             - define cmd 0
@@ -348,4 +349,3 @@ dmodels_quaternion_from_euler:
     - define y_q <location[0,1,0].to_axis_angle_quaternion[<[y]>]>
     - define z_q <location[0,0,1].to_axis_angle_quaternion[<[z]>]>
     - determine <[x_q].mul[<[y_q]>].mul[<[z_q]>]>
-

--- a/scripts/dmodels_main.dsc
+++ b/scripts/dmodels_main.dsc
@@ -9,9 +9,9 @@
 # @contributors Max^
 # @thanks Darwin, Max^, kalebbroo, sharklaserss - for helping with reference models, testing, ideas, etc
 # @date 2022/06/01
-# @updated 2023/09/08
+# @updated 2023/09/26
 # @denizen-build REL-1793
-# @script-version 2.1
+# @script-version 2.2
 #
 # This takes BlockBench "BBModel" files, converts them to a client-ready resource pack and Denizen internal data,
 # then is able to display them in minecraft and even animate them, by spawning and moving item display entities with resource pack items.
@@ -134,9 +134,9 @@ dmodels_config:
     # You can set the resource pack path to a custom path if you want.
     # Note that the default Denizen config requires this path start under "data/"
     resource_pack_path: data/dmodels/res_pack
-    # During the loading process the scale is shrunken down exactly 2.2 for items to allow bigger models in block bench so this brings it back up to default scale in-game (this is an estimate)
-    default_scale: 2.2
+    # During the loading process the scale is shrunken down for items to allow bigger models in block bench so this brings it back up to default scale in-game (this is an estimate)
+    default_scale: 4.8
     # You can optionally set the json indent for the resource pack to save space (0 for example).
     resource_pack_indent: 4
     # Set the resource pack version https://minecraft.fandom.com/wiki/Pack_format
-    resource_pack_version: 13
+    resource_pack_version: 15


### PR DESCRIPTION
- Removed the yaw quaternion as the item displays now rotate based on yaw and it also automatically rotates display translation.
- Added a 180 head display rotation in the y-axis in resource pack items to account for the 1.20.1 changes.
- Set the head display translation in the resource pack from 32|32|32 to -32|32|-32 due to the 180-degree rotation.
- Fixed global scale duplicating from reset_model_position and the new default scale is also now 4.8.
- Removed the dmodels_set_yaw task as it's no longer needed due to the removal of the yaw quaternion.
- Updated default resource pack version to 15 for 1.20.1.
- When using the reset_model_position or animating to center location yaw gets added by 180 to flip the model to the correct side.